### PR TITLE
[TASK] add user signature to post

### DIFF
--- a/Resources/Private/Templates/Post/List.html
+++ b/Resources/Private/Templates/Post/List.html
@@ -47,6 +47,10 @@
                             {post.text -> a:parser.parsedown()}
                         </div>
 
+                        <div>
+                            {post.creator.signature}
+                        </div>
+
 						<a:thread.editable thread="{thread}" user="{user}">
 							<f:link.action class="btn btn-default" action="new" arguments="{thread:thread, quotedPost:post}">
 								<f:translate key="tx_agora_domain_model_post.reply" />


### PR DESCRIPTION
if a user has a signature, it will be displayed underneath the post
we decided to show the current signature of the user, and not to persist the current signature with the post
