### PR TITLE
[TASK] -add email notifications for threads and forms

### DIFF
--- a/Classes/Controller/ActionController.php
+++ b/Classes/Controller/ActionController.php
@@ -116,5 +116,59 @@ class ActionController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
 		return $usergroupUids;
 	}
 
+    /**
+     * sendMail
+     *
+     * sends a mail via TYPO3 mailing API (swiftmailer)
+     *
+     * @param array $recipient recipient of the email in the format array('recipient@domain.tld' => 'Recipient Name')
+     * @param array $sender sender of the email in the format array('sender@domain.tld' => 'Sender Name')
+     * @param string $subject subject of the email
+     * @param string $templateName template name (UpperCamelCase)
+     * @param array $variables variables to be passed to the Fluid view
+     * @param array $replyTo reply to forthe email in the format array('reply@domain.tld' => 'Reply To Name')
+     * @return boolean TRUE on success, otherwise false
+     */
+    public function sendMail(array $recipient, array $sender, $subject, $templateName, array $variables = array(), $replyTo = array()) {
+        $emailView = $this->objectManager->get('\\TYPO3\\CMS\\Fluid\\View\\StandaloneView');
+        $extensionName = $this->request->getControllerExtensionName();
+        $emailView->getRequest()->setControllerExtensionName($extensionName);
+        $emailView->setFormat('html');
+        $extbaseFrameworkConfiguration = $this->configurationManager->getConfiguration(\TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK);
+        $layoutRootPath = \TYPO3\CMS\Core\Utility\GeneralUtility::getFileAbsFileName($extbaseFrameworkConfiguration['view']['layoutRootPath']).'../Email/Layouts/';
+        $emailView->setLayoutRootPath($layoutRootPath);
+        $partialRootPath = \TYPO3\CMS\Core\Utility\GeneralUtility::getFileAbsFileName($extbaseFrameworkConfiguration['view']['partialRootPath']).'../Email/Partials/';
+        $emailView->setPartialRootPath($partialRootPath);
+        $templateRootPath = \TYPO3\CMS\Core\Utility\GeneralUtility::getFileAbsFileName($extbaseFrameworkConfiguration['view']['templateRootPath']).'../Email/Templates/';
+        $templatePathAndFilename = $templateRootPath . $templateName . '.html';
+        $emailView->setTemplatePathAndFilename($templatePathAndFilename);
+        $emailView->assign('subject', $subject);
+        $emailView->assign('settings', $this->settings);
+        $emailView->assignMultiple($variables);
+        $emailBody = $emailView->render();
+
+        $message = $this->objectManager->get('\\TYPO3\\CMS\\Core\\Mail\\MailMessage');
+        $message->setTo($recipient)
+            ->setFrom($sender)
+            ->setSubject('Confirmation email');
+
+        if(!empty($replyTo)) {
+            $message->setReplyTo($replyTo);
+        }
+        // Plain text example
+        #$message->setBody($emailBody, 'text/plain')
+        // HTML Email
+        $message->setBody($emailBody, 'text/html');
+        $message->send();
+        return $message->isSent();
+    }
+
+    protected function getPostsDefaultSender(){
+        return array(  $this->settings['post']['defaultPostEmailAdress'] => $this->settings['post']['defaultPostEmailUserName']);
+    }
+
+    protected function getThreadDefaultSender(){
+        return array(  $this->settings['thread']['defaultThreadEmailAdress'] => $this->settings['thread']['defaultThreadEmailUserName']);
+    }
 
 }

--- a/Classes/Controller/ActionController.php
+++ b/Classes/Controller/ActionController.php
@@ -116,5 +116,51 @@ class ActionController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
 		return $usergroupUids;
 	}
 
+    /**
+     * sendMail
+     *
+     * sends a mail via TYPO3 mailing API (swiftmailer)
+     *
+     * @param array $recipient recipient of the email in the format array('recipient@domain.tld' => 'Recipient Name')
+     * @param array $sender sender of the email in the format array('sender@domain.tld' => 'Sender Name')
+     * @param string $subject subject of the email
+     * @param string $templateName template name (UpperCamelCase)
+     * @param array $variables variables to be passed to the Fluid view
+     * @param array $replyTo reply to forthe email in the format array('reply@domain.tld' => 'Reply To Name')
+     * @return boolean TRUE on success, otherwise false
+     */
+    public function sendMail(array $recipient, array $sender, $subject, $templateName, array $variables = array(), $replyTo = array()) {
+        $emailView = $this->objectManager->get('\\TYPO3\\CMS\\Fluid\\View\\StandaloneView');
+        $extensionName = $this->request->getControllerExtensionName();
+        $emailView->getRequest()->setControllerExtensionName($extensionName);
+        $emailView->setFormat('html');
+        $extbaseFrameworkConfiguration = $this->configurationManager->getConfiguration(\TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK);
+        $layoutRootPath = \TYPO3\CMS\Core\Utility\GeneralUtility::getFileAbsFileName($extbaseFrameworkConfiguration['view']['layoutRootPath']).'../Email/Layouts/';
+        $emailView->setLayoutRootPath($layoutRootPath);
+        $partialRootPath = \TYPO3\CMS\Core\Utility\GeneralUtility::getFileAbsFileName($extbaseFrameworkConfiguration['view']['partialRootPath']).'../Email/Partials/';
+        $emailView->setPartialRootPath($partialRootPath);
+        $templateRootPath = \TYPO3\CMS\Core\Utility\GeneralUtility::getFileAbsFileName($extbaseFrameworkConfiguration['view']['templateRootPath']).'../Email/Templates/';
+        $templatePathAndFilename = $templateRootPath . $templateName . '.html';
+        $emailView->setTemplatePathAndFilename($templatePathAndFilename);
+        $emailView->assign('subject', $subject);
+        $emailView->assign('settings', $this->settings);
+        $emailView->assignMultiple($variables);
+        $emailBody = $emailView->render();
+
+        $message = $this->objectManager->get('\\TYPO3\\CMS\\Core\\Mail\\MailMessage');
+        $message->setTo($recipient)
+            ->setFrom($sender)
+            ->setSubject('Confirmation email');
+
+        if(!empty($replyTo)) {
+            $message->setReplyTo($replyTo);
+        }
+        // Plain text example
+        #$message->setBody($emailBody, 'text/plain')
+        // HTML Email
+        $message->setBody($emailBody, 'text/html');
+        $message->send();
+        return $message->isSent();
+    }
 
 }

--- a/Classes/Controller/ForumController.php
+++ b/Classes/Controller/ForumController.php
@@ -2,127 +2,127 @@
 namespace AgoraTeam\Agora\Controller;
 
 
-/***************************************************************
- *
- *  Copyright notice
- *
- *  (c) 2015 Philipp Thiele <philipp.thiele@phth.de>
- *           Björn Christopher Bresser <bjoern.bresser@gmail.com>
- *
- *  All rights reserved
- *
- *  This script is part of the TYPO3 project. The TYPO3 project is
- *  free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  The GNU General Public License can be found at
- *  http://www.gnu.org/copyleft/gpl.html.
- *
- *  This script is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  This copyright notice MUST APPEAR in all copies of the script!
- ***************************************************************/
+    /***************************************************************
+     *
+     *  Copyright notice
+     *
+     *  (c) 2015 Philipp Thiele <philipp.thiele@phth.de>
+     *           Björn Christopher Bresser <bjoern.bresser@gmail.com>
+     *
+     *  All rights reserved
+     *
+     *  This script is part of the TYPO3 project. The TYPO3 project is
+     *  free software; you can redistribute it and/or modify
+     *  it under the terms of the GNU General Public License as published by
+     *  the Free Software Foundation; either version 3 of the License, or
+     *  (at your option) any later version.
+     *
+     *  The GNU General Public License can be found at
+     *  http://www.gnu.org/copyleft/gpl.html.
+     *
+     *  This script is distributed in the hope that it will be useful,
+     *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+     *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+     *  GNU General Public License for more details.
+     *
+     *  This copyright notice MUST APPEAR in all copies of the script!
+     ***************************************************************/
 
 /**
  * ForumController
  */
 class ForumController extends ActionController {
 
-	/**
-	 * forumRepository
-	 *
-	 * @var \AgoraTeam\Agora\Domain\Repository\ForumRepository
-	 * @inject
-	 */
-	protected $forumRepository = NULL;
+    /**
+     * forumRepository
+     *
+     * @var \AgoraTeam\Agora\Domain\Repository\ForumRepository
+     * @inject
+     */
+    protected $forumRepository = NULL;
 
-	/**
-	 * action list
-	 *
-	 * @return void
-	 */
-	public function listAction() {
-		$forums = $this->forumRepository->findVisibleRootForums();
-		$this->view->assignMultiple(
-			array(
-				'forums' => $forums,
-				'user' => $this->getUser()
-			)
-		);
-	}
+    /**
+     * action list
+     *
+     * @return void
+     */
+    public function listAction() {
+        $forums = $this->forumRepository->findVisibleRootForums();
+        $this->view->assignMultiple(
+            array(
+                'forums' => $forums,
+                'user' => $this->getUser()
+            )
+        );
+    }
 
-	/**
-	 * action show
-	 *
-	 * @param \AgoraTeam\Agora\Domain\Model\Forum $forum
-	 * @return void
-	 */
-	public function showAction(\AgoraTeam\Agora\Domain\Model\Forum $forum) {
-		$this->view->assign('forum', $forum);
-	}
+    /**
+     * action show
+     *
+     * @param \AgoraTeam\Agora\Domain\Model\Forum $forum
+     * @return void
+     */
+    public function showAction(\AgoraTeam\Agora\Domain\Model\Forum $forum) {
+        $this->view->assign('forum', $forum);
+    }
 
-	/**
-	 * action new
-	 *
-	 * @param \AgoraTeam\Agora\Domain\Model\Forum $newForum
-	 * @ignorevalidation $newForum
-	 * @return void
-	 */
-	public function newAction(\AgoraTeam\Agora\Domain\Model\Forum $newForum = NULL) {
-		$this->view->assign('newForum', $newForum);
-	}
+    /**
+     * action new
+     *
+     * @param \AgoraTeam\Agora\Domain\Model\Forum $newForum
+     * @ignorevalidation $newForum
+     * @return void
+     */
+    public function newAction(\AgoraTeam\Agora\Domain\Model\Forum $newForum = NULL) {
+        $this->view->assign('newForum', $newForum);
+    }
 
-	/**
-	 * action create
-	 *
-	 * @param \AgoraTeam\Agora\Domain\Model\Forum $newForum
-	 * @return void
-	 */
-	public function createAction(\AgoraTeam\Agora\Domain\Model\Forum $newForum) {
-		$this->addFlashMessage('The object was created. Please be aware that this action is publicly accessible unless you implement an access check. See <a href="http://wiki.typo3.org/T3Doc/Extension_Builder/Using_the_Extension_Builder#1._Model_the_domain" target="_blank">Wiki</a>', '', \TYPO3\CMS\Core\Messaging\AbstractMessage::ERROR);
-		$this->forumRepository->add($newForum);
-		$this->redirect('list');
-	}
+    /**
+     * action create
+     *
+     * @param \AgoraTeam\Agora\Domain\Model\Forum $newForum
+     * @return void
+     */
+    public function createAction(\AgoraTeam\Agora\Domain\Model\Forum $newForum) {
+        $this->addFlashMessage('The object was created. Please be aware that this action is publicly accessible unless you implement an access check. See <a href="http://wiki.typo3.org/T3Doc/Extension_Builder/Using_the_Extension_Builder#1._Model_the_domain" target="_blank">Wiki</a>', '', \TYPO3\CMS\Core\Messaging\AbstractMessage::ERROR);
+        $this->forumRepository->add($newForum);
+        $this->redirect('list');
+    }
 
-	/**
-	 * action edit
-	 *
-	 * @param \AgoraTeam\Agora\Domain\Model\Forum $forum
-	 * @ignorevalidation $forum
-	 * @return void
-	 */
-	public function editAction(\AgoraTeam\Agora\Domain\Model\Forum $forum) {
-		$this->view->assign('forum', $forum);
-	}
+    /**
+     * action edit
+     *
+     * @param \AgoraTeam\Agora\Domain\Model\Forum $forum
+     * @ignorevalidation $forum
+     * @return void
+     */
+    public function editAction(\AgoraTeam\Agora\Domain\Model\Forum $forum) {
+        $this->view->assign('forum', $forum);
+    }
 
-	/**
-	* action update
-    *
-	* @param \AgoraTeam\Agora\Domain\Model\Forum $forum
-	*
-	* @return void
-	*/
-	public function updateAction(\AgoraTeam\Agora\Domain\Model\Forum $forum) {
-		$this->addFlashMessage('The object was updated. Please be aware that this action is publicly accessible unless you implement an access check. See <a href="http://wiki.typo3.org/T3Doc/Extension_Builder/Using_the_Extension_Builder#1._Model_the_domain" target="_blank">Wiki</a>', '', \TYPO3\CMS\Core\Messaging\AbstractMessage::ERROR);
-		$this->forumRepository->update($forum);
-		$this->redirect('list');
-	}
+    /**
+     * action update
+     *
+     * @param \AgoraTeam\Agora\Domain\Model\Forum $forum
+     *
+     * @return void
+     */
+    public function updateAction(\AgoraTeam\Agora\Domain\Model\Forum $forum) {
+        $this->addFlashMessage('The object was updated. Please be aware that this action is publicly accessible unless you implement an access check. See <a href="http://wiki.typo3.org/T3Doc/Extension_Builder/Using_the_Extension_Builder#1._Model_the_domain" target="_blank">Wiki</a>', '', \TYPO3\CMS\Core\Messaging\AbstractMessage::ERROR);
+        $this->forumRepository->update($forum);
+        $this->redirect('list');
+    }
 
-	/**
-	 * action delete
-	 *
-	 * @param \AgoraTeam\Agora\Domain\Model\Forum $forum
-	 * @return void
-	 */
-	public function deleteAction(\AgoraTeam\Agora\Domain\Model\Forum $forum) {
-		$this->addFlashMessage('The object was deleted. Please be aware that this action is publicly accessible unless you implement an access check. See <a href="http://wiki.typo3.org/T3Doc/Extension_Builder/Using_the_Extension_Builder#1._Model_the_domain" target="_blank">Wiki</a>', '', \TYPO3\CMS\Core\Messaging\AbstractMessage::ERROR);
-		$this->forumRepository->remove($forum);
-		$this->redirect('list');
-	}
+    /**
+     * action delete
+     *
+     * @param \AgoraTeam\Agora\Domain\Model\Forum $forum
+     * @return void
+     */
+    public function deleteAction(\AgoraTeam\Agora\Domain\Model\Forum $forum) {
+        $this->addFlashMessage('The object was deleted. Please be aware that this action is publicly accessible unless you implement an access check. See <a href="http://wiki.typo3.org/T3Doc/Extension_Builder/Using_the_Extension_Builder#1._Model_the_domain" target="_blank">Wiki</a>', '', \TYPO3\CMS\Core\Messaging\AbstractMessage::ERROR);
+        $this->forumRepository->remove($forum);
+        $this->redirect('list');
+    }
 
 }

--- a/Classes/Controller/ForumController.php
+++ b/Classes/Controller/ForumController.php
@@ -1,32 +1,24 @@
 <?php
 namespace AgoraTeam\Agora\Controller;
 
-
-/***************************************************************
- *
- *  Copyright notice
- *
- *  (c) 2015 Philipp Thiele <philipp.thiele@phth.de>
- *           Björn Christopher Bresser <bjoern.bresser@gmail.com>
- *
- *  All rights reserved
- *
- *  This script is part of the TYPO3 project. The TYPO3 project is
- *  free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  The GNU General Public License can be found at
- *  http://www.gnu.org/copyleft/gpl.html.
- *
- *  This script is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  This copyright notice MUST APPEAR in all copies of the script!
- ***************************************************************/
+	/***************************************************************
+	 *  Copyright notice
+	 *  (c) 2015 Philipp Thiele <philipp.thiele@phth.de>
+	 *           Björn Christopher Bresser <bjoern.bresser@gmail.com>
+	 *  All rights reserved
+	 *  This script is part of the TYPO3 project. The TYPO3 project is
+	 *  free software; you can redistribute it and/or modify
+	 *  it under the terms of the GNU General Public License as published by
+	 *  the Free Software Foundation; either version 3 of the License, or
+	 *  (at your option) any later version.
+	 *  The GNU General Public License can be found at
+	 *  http://www.gnu.org/copyleft/gpl.html.
+	 *  This script is distributed in the hope that it will be useful,
+	 *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+	 *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	 *  GNU General Public License for more details.
+	 *  This copyright notice MUST APPEAR in all copies of the script!
+	 ***************************************************************/
 
 /**
  * ForumController
@@ -101,12 +93,11 @@ class ForumController extends ActionController {
 	}
 
 	/**
-	* action update
-    *
-	* @param \AgoraTeam\Agora\Domain\Model\Forum $forum
-	*
-	* @return void
-	*/
+	 * action update
+	 *
+	 * @param \AgoraTeam\Agora\Domain\Model\Forum $forum
+	 * @return void
+	 */
 	public function updateAction(\AgoraTeam\Agora\Domain\Model\Forum $forum) {
 		$this->addFlashMessage('The object was updated. Please be aware that this action is publicly accessible unless you implement an access check. See <a href="http://wiki.typo3.org/T3Doc/Extension_Builder/Using_the_Extension_Builder#1._Model_the_domain" target="_blank">Wiki</a>', '', \TYPO3\CMS\Core\Messaging\AbstractMessage::ERROR);
 		$this->forumRepository->update($forum);
@@ -124,5 +115,4 @@ class ForumController extends ActionController {
 		$this->forumRepository->remove($forum);
 		$this->redirect('list');
 	}
-
 }

--- a/Classes/Controller/PostController.php
+++ b/Classes/Controller/PostController.php
@@ -152,19 +152,21 @@ class PostController extends ActionController {
 		$this->view->assign('newPost', $newPost);
 		$this->view->assign('quotedPost', $quotedPost);
 		$this->view->assign('thread', $thread);
+
 	}
+
+    public function getCreator($post){
+        return $post->getCreator();
+    }
 
 	/**
 	 * action create
 	 *
 	 * @todo send info mails for subscribed users
-	 *
 	 * @param \AgoraTeam\Agora\Domain\Model\Post $newPost
-	 *
 	 * @return void
 	 */
 	public function createAction(\AgoraTeam\Agora\Domain\Model\Post $newPost) {
-
 		if(!$newPost->getThread()->isWritableForUser($this->getUser())) {
 			$this->addFlashMessage(
 				\TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate('tx_agora_domain_model_thread.flashMessages.editDenied.text', 'agora'),
@@ -173,20 +175,34 @@ class PostController extends ActionController {
 			);
 			$this->redirect('list', 'Post', 'agora', array('thread' => $newPost->getThread()));
 		}
-
 		$user = $this->getUser();
-
 		$newPost->setCreator($user);
 		$now = new \DateTime();
 		$newPost->setPublishingDate($now);
 		$this->postRepository->add($newPost);
-
 		$this->addFlashMessage(
 			\TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate('tx_agora_domain_model_post.flashMessages.created', 'agora'),
 			'',
 			\TYPO3\CMS\Core\Messaging\AbstractMessage::OK
 		);
-
+        if( ( $this->settings['post']['notificationsForPostOwner'] == 1 ) and  is_object($creator = $newPost->getQuotedPost()) )
+        {
+            $creator = $newPost->getQuotedPost()->getCreator();
+            $this->sendMail(
+                array(
+                    $creator->getEmail() => $creator->getDisplayName()
+                ),
+                array(
+                    $this->settings['post']['defaultPostEmailAdress'] =>  $this->settings['post']['defaultPostEmailUserName']
+                ),
+                \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate('email.updateDepotType.subject', 'depot'),
+                'NotificationToPostOwner',
+                array(
+                    'user' => $user,
+                    'post' => $newPost
+                )
+            );
+        }
 		$this->redirect(
 			'list',
 			'Post',
@@ -308,4 +324,5 @@ class PostController extends ActionController {
 		$latestPosts = $this->postRepository->findLatestPostsForUser($limit);
 		$this->view->assign('latestPosts', $latestPosts);
 	}
+
 }

--- a/Classes/Controller/ThreadController.php
+++ b/Classes/Controller/ThreadController.php
@@ -40,7 +40,7 @@ class ThreadController extends ActionController {
 	 * @inject
 	 */
 	protected $forumRepository = NULL;
-	
+
 	/**
 	 * threadRepository
 	 *

--- a/Classes/Controller/ThreadController.php
+++ b/Classes/Controller/ThreadController.php
@@ -89,7 +89,7 @@ class ThreadController extends ActionController {
 	public function newAction(\AgoraTeam\Agora\Domain\Model\Forum $forum,
 							  \AgoraTeam\Agora\Domain\Model\Thread $thread = NULL, $text = '') {
 
-		if(!$forum->isWritableForUser($this->getUser())) {
+        if(!$forum->isWritableForUser($this->getUser())) {
 			$this->addFlashMessage(
 				\TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate('tx_agora_domain_model_forum.flashMessages.editDenied.text', 'agora'),
 				\TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate('tx_agora_domain_model_forum.flashMessages.editDenied.headline', 'agora'),
@@ -98,7 +98,8 @@ class ThreadController extends ActionController {
 			$this->redirect('list', 'Thread', 'agora', array('forum' => $forum));
 		}
 
-		$this->view->assign('forum', $forum)
+
+        $this->view->assign('forum', $forum)
 					->assign('thread', $thread)
 					->assign('text', $text);
 	}
@@ -115,7 +116,6 @@ class ThreadController extends ActionController {
 	 */
 	public function createAction(\AgoraTeam\Agora\Domain\Model\Forum $forum,
 								 \AgoraTeam\Agora\Domain\Model\Thread $thread, $text) {
-
 		if(!$forum->isWritableForUser($this->getUser())) {
 			$this->addFlashMessage(
 				\TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate('tx_agora_domain_model_forum.flashMessages.editDenied.text', 'agora'),
@@ -148,13 +148,29 @@ class ThreadController extends ActionController {
 			'',
 			\TYPO3\CMS\Core\Messaging\AbstractMessage::OK
 		);
-
+        if( $this->settings['thread']['notificationsForThreadOwner'] == 1 ) {
+            $user = $this->getUser();
+            $this->sendMail(
+                array(
+                    $user->getEmail() => $user->getDisplayName()
+                ),
+                $this->getThreadDefaultSender(),
+                \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate('email.updateDepotType.subject', 'depot'),
+                'NotificationToThreadOwner',
+                array(
+                    'user' => $user,
+                    'thread' => $thread
+                )
+            );
+        }
 		$this->redirect(
 			'list',
 			'Thread',
 			'Agora',
 			array('forum' => $forum)
 		);
+
+
 	}
 
 	/**

--- a/Classes/Controller/ThreadController.php
+++ b/Classes/Controller/ThreadController.php
@@ -89,7 +89,7 @@ class ThreadController extends ActionController {
 	public function newAction(\AgoraTeam\Agora\Domain\Model\Forum $forum,
 							  \AgoraTeam\Agora\Domain\Model\Thread $thread = NULL, $text = '') {
 
-		if(!$forum->isWritableForUser($this->getUser())) {
+        if(!$forum->isWritableForUser($this->getUser())) {
 			$this->addFlashMessage(
 				\TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate('tx_agora_domain_model_forum.flashMessages.editDenied.text', 'agora'),
 				\TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate('tx_agora_domain_model_forum.flashMessages.editDenied.headline', 'agora'),
@@ -98,7 +98,8 @@ class ThreadController extends ActionController {
 			$this->redirect('list', 'Thread', 'agora', array('forum' => $forum));
 		}
 
-		$this->view->assign('forum', $forum)
+
+        $this->view->assign('forum', $forum)
 					->assign('thread', $thread)
 					->assign('text', $text);
 	}
@@ -115,7 +116,6 @@ class ThreadController extends ActionController {
 	 */
 	public function createAction(\AgoraTeam\Agora\Domain\Model\Forum $forum,
 								 \AgoraTeam\Agora\Domain\Model\Thread $thread, $text) {
-
 		if(!$forum->isWritableForUser($this->getUser())) {
 			$this->addFlashMessage(
 				\TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate('tx_agora_domain_model_forum.flashMessages.editDenied.text', 'agora'),
@@ -141,20 +141,38 @@ class ThreadController extends ActionController {
 		}
 
 		$forum->addThread($thread);
-		$this->forumRepository->update($forum);
+		//$this->forumRepository->update($forum);
 
 		$this->addFlashMessage(
 			\TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate('tx_agora_domain_model_forum.flashMessages.created', 'agora'),
 			'',
 			\TYPO3\CMS\Core\Messaging\AbstractMessage::OK
 		);
-
+        if( $this->settings['thread']['notificationsForThreadOwner'] == 1 ) {
+            $user = $this->getUser();
+            $this->sendMail(
+                array(
+                    $user->getEmail() => $user->getDisplayName()
+                ),
+                array(
+                    $this->settings['thread']['defaultThreadEmailAdress'] =>  $this->settings['thread']['defaultThreadEmailUserName']
+                ),
+                \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate('email.updateDepotType.subject', 'depot'),
+                'NotificationToThreadOwner',
+                array(
+                    'user' => $user,
+                    'thread' => $thread
+                )
+            );
+        }
 		$this->redirect(
 			'list',
 			'Thread',
 			'Agora',
 			array('forum' => $forum)
 		);
+
+
 	}
 
 	/**

--- a/Classes/Controller/ThreadController.php
+++ b/Classes/Controller/ThreadController.php
@@ -89,7 +89,7 @@ class ThreadController extends ActionController {
 	public function newAction(\AgoraTeam\Agora\Domain\Model\Forum $forum,
 							  \AgoraTeam\Agora\Domain\Model\Thread $thread = NULL, $text = '') {
 
-		if(!$forum->isWritableForUser($this->getUser())) {
+        if(!$forum->isWritableForUser($this->getUser())) {
 			$this->addFlashMessage(
 				\TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate('tx_agora_domain_model_forum.flashMessages.editDenied.text', 'agora'),
 				\TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate('tx_agora_domain_model_forum.flashMessages.editDenied.headline', 'agora'),
@@ -98,7 +98,8 @@ class ThreadController extends ActionController {
 			$this->redirect('list', 'Thread', 'agora', array('forum' => $forum));
 		}
 
-		$this->view->assign('forum', $forum)
+
+        $this->view->assign('forum', $forum)
 					->assign('thread', $thread)
 					->assign('text', $text);
 	}
@@ -115,7 +116,6 @@ class ThreadController extends ActionController {
 	 */
 	public function createAction(\AgoraTeam\Agora\Domain\Model\Forum $forum,
 								 \AgoraTeam\Agora\Domain\Model\Thread $thread, $text) {
-
 		if(!$forum->isWritableForUser($this->getUser())) {
 			$this->addFlashMessage(
 				\TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate('tx_agora_domain_model_forum.flashMessages.editDenied.text', 'agora'),
@@ -141,20 +141,36 @@ class ThreadController extends ActionController {
 		}
 
 		$forum->addThread($thread);
-		$this->forumRepository->update($forum);
+		//$this->forumRepository->update($forum);
 
 		$this->addFlashMessage(
 			\TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate('tx_agora_domain_model_forum.flashMessages.created', 'agora'),
 			'',
 			\TYPO3\CMS\Core\Messaging\AbstractMessage::OK
 		);
-
+        if( $this->settings['thread']['notificationsForThreadOwner'] == 1 ) {
+            $user = $this->getUser();
+            $this->sendMail(
+                array(
+                    $user->getEmail() => $user->getDisplayName()
+                ),
+                $this->getThreadDefaultSender(),
+                \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate('email.updateDepotType.subject', 'depot'),
+                'NotificationToThreadOwner',
+                array(
+                    'user' => $user,
+                    'thread' => $thread
+                )
+            );
+        }
 		$this->redirect(
 			'list',
 			'Thread',
 			'Agora',
 			array('forum' => $forum)
 		);
+
+
 	}
 
 	/**

--- a/Classes/Domain/Model/Post.php
+++ b/Classes/Domain/Model/Post.php
@@ -263,6 +263,7 @@ class Post extends Entity {
      */
     public function addReply(\AgoraTeam\Agora\Domain\Model\Post $reply) {
         $this->replies->attach($reply);
+
     }
 
     /**
@@ -321,6 +322,7 @@ class Post extends Entity {
 	 */
 	public function addAttachment(\AgoraTeam\Agora\Domain\Model\Attachment $attachment) {
 		$this->attachments->attach($attachment);
+
 	}
 
 	/**

--- a/Classes/Domain/Repository/PostRepository.php
+++ b/Classes/Domain/Repository/PostRepository.php
@@ -65,6 +65,4 @@ class PostRepository extends Repository {
 		return $result;
 	}
 
-
-
 }

--- a/Classes/ViewHelpers/CreatorViewHelper.php
+++ b/Classes/ViewHelpers/CreatorViewHelper.php
@@ -49,10 +49,10 @@ class CreatorViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHel
         );
 
         $username = '';
-        if(is_a($object->getCreator(), '\AgoraTeam\Agora\Domain\Model\User')) {
+
+        if(is_object($object->getCreator())) {
             $username = $object->getCreator()->getDisplayName();
         } else {
-
             $username = $settings['post']['defaultCreatorName'];
         }
         return $username;

--- a/Configuration/TypoScript/Main/setup.txt
+++ b/Configuration/TypoScript/Main/setup.txt
@@ -49,12 +49,18 @@ plugin.tx_agora {
             numberOfItemsPerPage = 10
 			dateFormat = m-d-y h:i
 			numberOfItemsInObservedThreadsWidget = 5
+            notificationsForThreadOwner = 1
+            defaultThreadEmailAdress = philipp.thiele@phth.de
+            defaultThreadEmailUserName = ThreadAdmin
         }
         post {
 			numberOfItemsInLatestView = 10
             numberOfItemsPerPage = 10
             dateFormat = m-d-y h:i
             defaultCreatorName = Anonymous
+            notificationsForPostOwner = 1
+            defaultPostEmailAdress = philipp.thiele@phth.de
+            defaultPostEmailUserName = PostAdmin
         }
     }
 }

--- a/Configuration/TypoScript/Main/setup.txt
+++ b/Configuration/TypoScript/Main/setup.txt
@@ -50,7 +50,7 @@ plugin.tx_agora {
 			dateFormat = m-d-y h:i
 			numberOfItemsInObservedThreadsWidget = 5
             notificationsForThreadOwner = 1
-            defaultThreadEmailAdress = philipp.thiele@phth.de
+            defaultThreadEmailAdress = email_adress@example.de
             defaultThreadEmailUserName = ThreadAdmin
         }
         post {
@@ -59,7 +59,7 @@ plugin.tx_agora {
             dateFormat = m-d-y h:i
             defaultCreatorName = Anonymous
             notificationsForPostOwner = 1
-            defaultPostEmailAdress = philipp.thiele@phth.de
+            defaultPostEmailAdress = email_aress@example.de
             defaultPostEmailUserName = PostAdmin
         }
     }

--- a/Resources/Private/Email/Layouts/Default.html
+++ b/Resources/Private/Email/Layouts/Default.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <f:comment>
+        email template taken from http://zurb.com/playground/projects/responsive-email-templates/basic.html
+    </f:comment>
+    <meta name="viewport" content="width=device-width"/>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <title>{subject}</title>
+</head>
+<body bgcolor="#FFFFFF">
+
+<table class="body-wrap">
+    <tr>
+        <td></td>
+        <td class="container" bgcolor="#FFFFFF">
+            <div class="content">
+                <table>
+                    <tr>
+                        <td>
+                            <f:render section="main" />
+                        </td>
+                    </tr>
+                </table>
+            </div>
+        </td>
+        <td></td>
+    </tr>
+</table>
+</body>
+</html>

--- a/Resources/Private/Email/Templates/NotificationToPostOwner.html
+++ b/Resources/Private/Email/Templates/NotificationToPostOwner.html
@@ -1,0 +1,13 @@
+<f:layout name="Default" />
+<f:section name="main">
+    <h1>{subject}</h1>
+    <h1>
+        <f:translate key="email_postownernotificationgeetings" /> {user.displayName}
+    </h1>
+    <p>
+        <f:translate key="email_postownernotificationmessage" arguments="{0:'{post.quotedPost.text}', 1:'{f:format.date(date: \'NOW\', format: \'d.m.Y H:i:s\')}'}"  />
+    </p>
+    <p>
+        <f:translate key="email_postownernotificationend" />
+    </p>
+</f:section>

--- a/Resources/Private/Email/Templates/NotificationToThreadOwner.html
+++ b/Resources/Private/Email/Templates/NotificationToThreadOwner.html
@@ -1,0 +1,14 @@
+<f:layout name="Default" />
+<f:section name="main">
+    <h1>{subject}</h1>
+    <h1>
+        <f:translate key="email_ownernotificationgeetings" /> {user.displayName}
+
+    </h1>
+    <p>
+        <f:translate key="email_ownernotificationmessage"  arguments="{0:'{thread.title}', 1:'{f:format.date(date: \'NOW\', format: \'d.m.Y H:i:s\')}'}"  />
+    </p>
+    <p>
+        <f:translate key="email_ownernotificationend" />
+    </p>
+</f:section>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -346,6 +346,25 @@
 			<trans-unit id="tx_agora_domain_model_view.user">
 				<source>User</source>
 			</trans-unit>
+			<trans-unit id="email_ownernotificationgeetings">
+                <source>Hello</source>
+            </trans-unit>
+            <trans-unit id="email_ownernotificationmessage">
+                <source>Your thread %s was succesfully created at %s.</source>
+            </trans-unit>
+            <trans-unit id="email_ownernotificationend">
+                <source>Thank you!</source>
+            </trans-unit>
+            <trans-unit id="email_postownernotificationgeetings">
+                <source>Hello</source>
+            </trans-unit>
+            <trans-unit id="email_postownernotificationmessage">
+                <source>Your post %s  was just  commented at  %s.</source>
+            </trans-unit>
+            <trans-unit id="email_postownernotificationend">
+                <source>Have a nice day!</source>
+            </trans-unit>
+
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Templates/Post/List.html
+++ b/Resources/Private/Templates/Post/List.html
@@ -47,6 +47,10 @@
                             {post.text -> a:parser.parsedown()}
                         </div>
 
+                        <div>
+                            {post.creator.signature}
+                        </div>
+
 						<a:thread.editable thread="{thread}" user="{user}">
 							<f:link.action class="btn btn-default" action="new" arguments="{thread:thread, quotedPost:post}">
 								<f:translate key="tx_agora_domain_model_post.reply" />


### PR DESCRIPTION
A thread's owner will be informed (will receive a email) when it's form was succesfully created.
A post's owner will be informed (will receive a email) when someone comments his post.
Administrators can deactivate the notification for all the forms and all the threads
